### PR TITLE
Version v0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yreflow"
-version = "0.2.2"
+version = "0.2.3"
 authors = [
     { name="Kredden", email="kredden@proactiveapathy.com" }
 ]

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,0 +1,330 @@
+"""Tests for context-aware tab completion."""
+
+import pytest
+import pytest_asyncio
+
+from yreflow.protocol.events import EventBus
+from yreflow.protocol.model_store import ModelStore
+from yreflow.commands.completion import (
+    CompletionType,
+    detect_completion_context,
+    resolve_names,
+)
+
+
+# ---------------------------------------------------------------------------
+# detect_completion_context tests
+# ---------------------------------------------------------------------------
+
+class TestDetectCompletionContext:
+    """Test command-prefix detection and slot identification."""
+
+    # --- Directed commands: name slot (before =) ---
+
+    @pytest.mark.parametrize("text,expected_type", [
+        ("w Jo",          CompletionType.LOCAL_ONLY),
+        ("wh Jo",         CompletionType.LOCAL_ONLY),
+        ("@Jo",           CompletionType.LOCAL_ONLY),
+        ("address Jo",    CompletionType.LOCAL_ONLY),
+        ("to Jo",         CompletionType.LOCAL_ONLY),
+    ])
+    def test_directed_name_slot_local_only(self, text, expected_type):
+        ctx = detect_completion_context(text)
+        assert ctx.completion_type == expected_type
+        assert ctx.prose is False
+
+    @pytest.mark.parametrize("text,expected_type", [
+        ("p Jo",          CompletionType.AWAKE_WATCH_PREFERRED),
+        ("m Jo",          CompletionType.AWAKE_WATCH_PREFERRED),
+    ])
+    def test_directed_name_slot_awake_watch(self, text, expected_type):
+        ctx = detect_completion_context(text)
+        assert ctx.completion_type == expected_type
+        assert ctx.prose is False
+
+    @pytest.mark.parametrize("text,expected_type", [
+        ("mail send Jo",  CompletionType.WATCH_PREFERRED),
+        ("mail s Jo",     CompletionType.WATCH_PREFERRED),
+    ])
+    def test_directed_name_slot_watch(self, text, expected_type):
+        ctx = detect_completion_context(text)
+        assert ctx.completion_type == expected_type
+        assert ctx.prose is False
+
+    # --- Directed commands: message slot (after =) ---
+
+    def test_whisper_after_eq(self):
+        ctx = detect_completion_context("w John=hey Tho")
+        assert ctx.completion_type == CompletionType.LOCAL_PREFERRED
+        assert ctx.prefix == "Tho"
+        assert ctx.prose is True
+
+    def test_page_after_eq(self):
+        ctx = detect_completion_context("m John=hey Tho")
+        assert ctx.completion_type == CompletionType.WATCH_PREFERRED
+        assert ctx.prefix == "Tho"
+        assert ctx.prose is True
+
+    def test_address_after_eq(self):
+        ctx = detect_completion_context("@John=hey Tho")
+        assert ctx.completion_type == CompletionType.LOCAL_PREFERRED
+        assert ctx.prefix == "Tho"
+        assert ctx.prose is True
+
+    # --- Undirected prose commands ---
+
+    @pytest.mark.parametrize("text", [
+        "say hello Tho",
+        '"hello Tho',
+        "\u201chello Tho",
+        ":waves to Tho",
+        "pose waves to Tho",
+        ">ooc Tho",
+        "ooc Tho",
+    ])
+    def test_prose_commands_local_preferred(self, text):
+        ctx = detect_completion_context(text)
+        assert ctx.completion_type == CompletionType.LOCAL_PREFERRED
+        assert ctx.prefix == "Tho"
+        assert ctx.prose is True
+
+    # --- Undirected name-target commands ---
+
+    @pytest.mark.parametrize("text,expected_type", [
+        ("look Tho",      CompletionType.LOCAL_ONLY),
+        ("l Tho",         CompletionType.LOCAL_ONLY),
+        ("lead Tho",      CompletionType.LOCAL_ONLY),
+        ("follow Tho",    CompletionType.LOCAL_ONLY),
+        ("focus Tho",     CompletionType.LOCAL_ONLY),
+        ("unfocus Tho",   CompletionType.LOCAL_ONLY),
+    ])
+    def test_name_commands_local_only(self, text, expected_type):
+        ctx = detect_completion_context(text)
+        assert ctx.completion_type == expected_type
+        assert ctx.prefix == "Tho"
+        assert ctx.prose is False
+
+    @pytest.mark.parametrize("text,expected_type", [
+        ("whois Tho",     CompletionType.WATCH_PREFERRED),
+        ("wi Tho",        CompletionType.WATCH_PREFERRED),
+        ("watch Tho",     CompletionType.WATCH_PREFERRED),
+        ("unwatch Tho",   CompletionType.WATCH_PREFERRED),
+        ("summon Tho",    CompletionType.WATCH_PREFERRED),
+        ("join Tho",      CompletionType.WATCH_PREFERRED),
+    ])
+    def test_name_commands_watch_preferred(self, text, expected_type):
+        ctx = detect_completion_context(text)
+        assert ctx.completion_type == expected_type
+        assert ctx.prefix == "Tho"
+        assert ctx.prose is False
+
+    # --- Prefix extraction ---
+
+    def test_prefix_extraction_directed(self):
+        ctx = detect_completion_context("w Thorn Ash")
+        assert ctx.prefix == "Thorn Ash"
+
+    def test_prefix_extraction_at_stripped(self):
+        ctx = detect_completion_context("@Tho")
+        assert ctx.prefix == "Tho"
+
+    def test_prefix_extraction_look_multiword(self):
+        ctx = detect_completion_context("look Thorn Ash")
+        assert ctx.prefix == "Thorn Ash"
+
+    def test_prefix_extraction_prose_last_word(self):
+        ctx = detect_completion_context("say hello there Tho")
+        assert ctx.prefix == "Tho"
+
+    # --- Bare text (treated as say) ---
+
+    def test_bare_text(self):
+        ctx = detect_completion_context("hello Tho")
+        assert ctx.completion_type == CompletionType.LOCAL_PREFERRED
+        assert ctx.prefix == "Tho"
+        assert ctx.prose is True
+
+    # --- Edge cases ---
+
+    def test_empty_input(self):
+        ctx = detect_completion_context("")
+        assert ctx.prefix == ""
+
+    def test_wh_longer_prefix_not_shadowed_by_w(self):
+        """'wh ' should match before 'w ' would match 'wh'."""
+        ctx = detect_completion_context("wh Thorn")
+        assert ctx.completion_type == CompletionType.LOCAL_ONLY
+        assert ctx.prefix == "Thorn"
+
+
+# ---------------------------------------------------------------------------
+# resolve_names tests
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def completion_store():
+    """ModelStore with room chars, watch list, and online-only chars."""
+    store = ModelStore(event_bus=EventBus())
+
+    # --- Characters ---
+    # Room occupants: Alice Bloom, Bob Cedar
+    for char_id, name, surname, awake in [
+        ("alice01", "Alice", "Bloom", True),
+        ("bob02", "Bob", "Cedar", True),
+        ("carol03", "Carol", "Dune", True),    # watch list only
+        ("dave04", "Dave", "Elm", True),        # online only
+        ("eve05", "Eve", "Frost", False),       # asleep (in watch list)
+        ("alice06", "Alice", "Stone", True),    # online only, same first name
+    ]:
+        await store.set(f"core.char.{char_id}", {
+            "id": char_id,
+            "name": name,
+            "surname": surname,
+            "awake": awake,
+        })
+
+    # --- Room setup: alice01 and bob02 are in the room ---
+    room_id = "room01"
+    await store.set(f"core.room.{room_id}", {"id": room_id, "name": "Test Room"})
+    await store.set(f"core.room.{room_id}.chars", {
+        "_value": [
+            {"rid": "core.char.alice01.inroom"},
+            {"rid": "core.char.bob02.inroom"},
+        ]
+    })
+
+    # Set up character's inRoom pointer
+    await store.set("core.char.alice01.owned", {
+        "inRoom": {"rid": f"core.room.{room_id}"},
+    })
+
+    # --- Watch list: carol03 and eve05 ---
+    player = "player01"
+    await store.set(f"note.player.{player}.watches", {
+        "w1": {"rid": f"note.player.{player}.watches.w1"},
+        "w2": {"rid": f"note.player.{player}.watches.w2"},
+    })
+    await store.set(f"note.player.{player}.watches.w1", {
+        "char": {"rid": "core.char.carol03.info"},
+    })
+    await store.set(f"note.player.{player}.watches.w2", {
+        "char": {"rid": "core.char.eve05.info"},
+    })
+
+    return store
+
+
+CHAR_PATH = "core.char.alice01"
+PLAYER = "player01"
+
+
+class TestResolveNames:
+
+    def test_local_only_returns_room_chars(self, completion_store):
+        results = resolve_names(
+            completion_store, "", CompletionType.LOCAL_ONLY,
+            CHAR_PATH, PLAYER, prose=False,
+        )
+        assert "Alice Bloom" in results
+        assert "Bob Cedar" in results
+        assert "Carol Dune" not in results
+        assert "Dave Elm" not in results
+
+    def test_local_preferred_room_first(self, completion_store):
+        results = resolve_names(
+            completion_store, "", CompletionType.LOCAL_PREFERRED,
+            CHAR_PATH, PLAYER, prose=False,
+        )
+        # Room chars come first
+        room_names = {"Alice Bloom", "Bob Cedar"}
+        first_two = set(results[:2])
+        assert first_two == room_names
+        # Watch list and online chars also present
+        assert "Carol Dune" in results
+        assert "Dave Elm" in results
+
+    def test_local_preferred_deduplication(self, completion_store):
+        results = resolve_names(
+            completion_store, "", CompletionType.LOCAL_PREFERRED,
+            CHAR_PATH, PLAYER, prose=False,
+        )
+        # Alice Bloom should appear once (room), not again (online)
+        assert results.count("Alice Bloom") == 1
+
+    def test_awake_watch_preferred_excludes_sleeping(self, completion_store):
+        results = resolve_names(
+            completion_store, "", CompletionType.AWAKE_WATCH_PREFERRED,
+            CHAR_PATH, PLAYER, prose=False,
+        )
+        # Eve is asleep and on watch list — should be excluded
+        assert "Eve Frost" not in results
+        # Carol is awake and on watch list — should be first
+        assert results[0] == "Carol Dune"
+
+    def test_watch_preferred_includes_sleeping(self, completion_store):
+        results = resolve_names(
+            completion_store, "", CompletionType.WATCH_PREFERRED,
+            CHAR_PATH, PLAYER, prose=False,
+        )
+        # Eve is on watch list — should be included (watch_preferred doesn't filter awake)
+        assert "Eve Frost" in results
+        # Watch list chars come before online-only chars
+        carol_idx = results.index("Carol Dune")
+        dave_idx = results.index("Dave Elm")
+        assert carol_idx < dave_idx
+
+    def test_prefix_matching(self, completion_store):
+        results = resolve_names(
+            completion_store, "Ali", CompletionType.LOCAL_PREFERRED,
+            CHAR_PATH, PLAYER, prose=False,
+        )
+        assert "Alice Bloom" in results
+        assert "Alice Stone" in results
+        assert "Bob Cedar" not in results
+
+    def test_prefix_case_insensitive(self, completion_store):
+        results = resolve_names(
+            completion_store, "ali", CompletionType.LOCAL_ONLY,
+            CHAR_PATH, PLAYER, prose=False,
+        )
+        assert "Alice Bloom" in results
+
+    def test_prose_interleaves_firstname_fullname(self, completion_store):
+        results = resolve_names(
+            completion_store, "Ali", CompletionType.LOCAL_PREFERRED,
+            CHAR_PATH, PLAYER, prose=True,
+        )
+        # Should be: Alice, Alice Bloom (room), Alice, Alice Stone (online)
+        assert results[0] == "Alice"
+        assert results[1] == "Alice Bloom"
+        assert results[2] == "Alice"
+        assert results[3] == "Alice Stone"
+
+    def test_prose_no_duplicate_when_no_surname(self, completion_store):
+        """If fullname == firstname (no surname), only list once."""
+        # Add a character with no surname
+        import asyncio
+        asyncio.get_event_loop().run_until_complete(
+            completion_store.set("core.char.zara07", {
+                "id": "zara07", "name": "Zara", "surname": "", "awake": True,
+            })
+        )
+        results = resolve_names(
+            completion_store, "Zar", CompletionType.LOCAL_PREFERRED,
+            CHAR_PATH, PLAYER, prose=True,
+        )
+        assert results.count("Zara") == 1
+
+    def test_none_type_returns_empty(self, completion_store):
+        results = resolve_names(
+            completion_store, "Ali", CompletionType.NONE,
+            CHAR_PATH, PLAYER, prose=False,
+        )
+        assert results == []
+
+    def test_no_match_returns_empty(self, completion_store):
+        results = resolve_names(
+            completion_store, "Zzzzz", CompletionType.LOCAL_PREFERRED,
+            CHAR_PATH, PLAYER, prose=False,
+        )
+        assert results == []

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -9,6 +9,8 @@ from yreflow.commands.completion import (
     CompletionType,
     detect_completion_context,
     resolve_names,
+    resolve_exits,
+    resolve_teleport_nodes,
 )
 
 
@@ -327,4 +329,160 @@ class TestResolveNames:
             completion_store, "Zzzzz", CompletionType.LOCAL_PREFERRED,
             CHAR_PATH, PLAYER, prose=False,
         )
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# detect_completion_context: go / teleport / tport
+# ---------------------------------------------------------------------------
+
+class TestDetectCompletionContextGoTeleport:
+
+    @pytest.mark.parametrize("text", ["go mar", "go north"])
+    def test_go_exits(self, text):
+        ctx = detect_completion_context(text)
+        assert ctx.completion_type == CompletionType.EXITS
+        assert ctx.prose is False
+
+    def test_go_prefix_extraction(self):
+        ctx = detect_completion_context("go mar")
+        assert ctx.prefix == "mar"
+
+    @pytest.mark.parametrize("text,expected_prefix", [
+        ("teleport hom", "hom"),
+        ("tport hom", "hom"),
+        ("t hom", "hom"),
+    ])
+    def test_teleport_nodes(self, text, expected_prefix):
+        ctx = detect_completion_context(text)
+        assert ctx.completion_type == CompletionType.TELEPORT_NODES
+        assert ctx.prefix == expected_prefix
+        assert ctx.prose is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_exits tests
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def exit_store():
+    """ModelStore with room exits."""
+    store = ModelStore(event_bus=EventBus())
+
+    room_id = "room01"
+    await store.set(f"core.room.{room_id}", {"id": room_id, "name": "Test Room"})
+
+    # Set up exits
+    exit0_rid = f"core.room.{room_id}.exit.exit000"
+    await store.set(exit0_rid, {
+        "id": "exit000", "name": "Market Square",
+        "keys": {"data": ["market", "north"]},
+    })
+    exit1_rid = f"core.room.{room_id}.exit.exit001"
+    await store.set(exit1_rid, {
+        "id": "exit001", "name": "Back Alley",
+        "keys": {"data": ["alley", "south"]},
+    })
+    await store.set(f"core.room.{room_id}.exits", {
+        "_value": [{"rid": exit0_rid}, {"rid": exit1_rid}]
+    })
+
+    # Character in this room
+    await store.set("core.char.char01.owned", {
+        "inRoom": {"rid": f"core.room.{room_id}"},
+    })
+
+    return store
+
+
+class TestResolveExits:
+
+    def test_all_exits_with_empty_prefix(self, exit_store):
+        results = resolve_exits(exit_store, "", "core.char.char01")
+        assert "Market Square" in results
+        assert "Back Alley" in results
+
+    def test_exit_name_prefix_match(self, exit_store):
+        results = resolve_exits(exit_store, "Mar", "core.char.char01")
+        assert "Market Square" in results
+        assert "Back Alley" not in results
+
+    def test_exit_key_prefix_match(self, exit_store):
+        results = resolve_exits(exit_store, "nor", "core.char.char01")
+        assert "north" in results
+        assert "Market Square" not in results  # "Market" doesn't start with "nor"
+
+    def test_case_insensitive(self, exit_store):
+        results = resolve_exits(exit_store, "back", "core.char.char01")
+        assert "Back Alley" in results
+
+    def test_no_char_path_returns_empty(self, exit_store):
+        results = resolve_exits(exit_store, "", None)
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_teleport_nodes tests
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def teleport_store():
+    """ModelStore with character-specific and global teleport nodes."""
+    store = ModelStore(event_bus=EventBus())
+
+    # Character-specific nodes
+    char_node_rid = "core.node.charnode01"
+    await store.set(char_node_rid, {"id": "charnode01", "key": "home"})
+    await store.set("core.char.char01.nodes", {
+        "_value": [{"rid": char_node_rid}],
+    })
+
+    # Global nodes
+    await store.set("core.node.global01", {"id": "global01", "key": "haven"})
+    await store.set("core.node.global02", {"id": "global02", "key": "hub"})
+
+    return store
+
+
+class TestResolveTeleportNodes:
+
+    def test_char_specific_nodes(self, teleport_store):
+        results = resolve_teleport_nodes(teleport_store, "ho", "core.char.char01")
+        assert "home" in results
+
+    def test_global_nodes(self, teleport_store):
+        results = resolve_teleport_nodes(teleport_store, "ha", "core.char.char01")
+        assert "haven" in results
+
+    def test_all_nodes_with_h_prefix(self, teleport_store):
+        results = resolve_teleport_nodes(teleport_store, "h", "core.char.char01")
+        assert "home" in results
+        assert "haven" in results
+        assert "hub" in results
+
+    def test_char_nodes_before_global(self, teleport_store):
+        """Character-specific nodes should appear before global nodes."""
+        results = resolve_teleport_nodes(teleport_store, "h", "core.char.char01")
+        home_idx = results.index("home")
+        haven_idx = results.index("haven")
+        assert home_idx < haven_idx
+
+    def test_deduplication(self, teleport_store):
+        """If a key appears in both char and global, only list once."""
+        import asyncio
+        # Add "home" as a global node too
+        asyncio.get_event_loop().run_until_complete(
+            teleport_store.set("core.node.global03", {"id": "global03", "key": "home"})
+        )
+        results = resolve_teleport_nodes(teleport_store, "ho", "core.char.char01")
+        assert results.count("home") == 1
+
+    def test_no_char_path_still_returns_global(self, teleport_store):
+        results = resolve_teleport_nodes(teleport_store, "h", None)
+        assert "haven" in results
+        assert "hub" in results
+        assert "home" not in results  # char-specific only
+
+    def test_no_match_returns_empty(self, teleport_store):
+        results = resolve_teleport_nodes(teleport_store, "zzz", "core.char.char01")
         assert results == []

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -440,6 +440,9 @@ async def teleport_store():
     # Global nodes
     await store.set("core.node.global01", {"id": "global01", "key": "haven"})
     await store.set("core.node.global02", {"id": "global02", "key": "hub"})
+    await store.set("core.nodes", {
+        "_value": [{"rid": "core.node.global01"}, {"rid": "core.node.global02"}],
+    })
 
     return store
 
@@ -470,10 +473,14 @@ class TestResolveTeleportNodes:
     def test_deduplication(self, teleport_store):
         """If a key appears in both char and global, only list once."""
         import asyncio
+        loop = asyncio.get_event_loop()
         # Add "home" as a global node too
-        asyncio.get_event_loop().run_until_complete(
+        loop.run_until_complete(
             teleport_store.set("core.node.global03", {"id": "global03", "key": "home"})
         )
+        # Add it to the global nodes collection
+        cur = teleport_store.get("core.nodes._value")
+        cur.append({"rid": "core.node.global03"})
         results = resolve_teleport_nodes(teleport_store, "ho", "core.char.char01")
         assert results.count("home") == 1
 

--- a/uv.lock
+++ b/uv.lock
@@ -638,7 +638,7 @@ wheels = [
 
 [[package]]
 name = "yreflow"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "base91" },

--- a/uv.lock
+++ b/uv.lock
@@ -638,7 +638,7 @@ wheels = [
 
 [[package]]
 name = "yreflow"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "base91" },

--- a/yreflow/commands/completion.py
+++ b/yreflow/commands/completion.py
@@ -301,15 +301,16 @@ def resolve_teleport_nodes(
 
     # Global nodes
     try:
-        nodes = store.get("core.node")
-        for node_key in nodes:
-            node_data = nodes[node_key]
-            if not isinstance(node_data, dict):
+        global_refs = store.get("core.nodes._value")
+        for ref in global_refs:
+            try:
+                node_data = store.get(ref["rid"])
+                key = node_data.get("key", "")
+                if key and key not in seen and _matches_prefix(key, prefix):
+                    results.append(key)
+                    seen.add(key)
+            except (KeyError, TypeError):
                 continue
-            key = node_data.get("key", "")
-            if key and key not in seen and _matches_prefix(key, prefix):
-                results.append(key)
-                seen.add(key)
     except KeyError:
         pass
 

--- a/yreflow/commands/completion.py
+++ b/yreflow/commands/completion.py
@@ -15,6 +15,8 @@ class CompletionType(Enum):
     LOCAL_PREFERRED = auto()       # room → watch → online
     AWAKE_WATCH_PREFERRED = auto() # awake only, watch → online
     WATCH_PREFERRED = auto()       # watch → online
+    EXITS = auto()                 # room exit names/keys
+    TELEPORT_NODES = auto()        # teleport node keys
     NONE = auto()                  # no name completion
 
 
@@ -62,6 +64,8 @@ _UNDIRECTED_NAME_RULES: list[tuple[tuple[str, ...], CompletionType]] = [
     (("follow ",),            CompletionType.LOCAL_ONLY),
     (("focus ",),             CompletionType.LOCAL_ONLY),
     (("unfocus ",),           CompletionType.LOCAL_ONLY),
+    (("go ",),                CompletionType.EXITS),
+    (("teleport ", "tport ", "t "), CompletionType.TELEPORT_NODES),
 ]
 
 
@@ -232,5 +236,81 @@ def resolve_names(
                     results.append(fullname)
             else:
                 results.append(fullname)
+
+    return results
+
+
+def resolve_exits(
+    store: ModelStore,
+    prefix: str,
+    char_path: str | None,
+) -> list[str]:
+    """Build a list of matching exit names for the current room."""
+    if not char_path:
+        return []
+    room_pointer = store.get_room_rid(char_path)
+    if not room_pointer:
+        return []
+
+    results: list[str] = []
+    for entry in store.get_room_exits(room_pointer):
+        try:
+            exit_data = store.get(entry["rid"])
+        except (KeyError, TypeError):
+            continue
+        name = exit_data.get("name", "")
+        if name and _matches_prefix(name, prefix):
+            results.append(name)
+        # Also match on exit keys (e.g. "north", "market")
+        keys_data = exit_data.get("keys", {})
+        key_list = keys_data.get("data", keys_data) if isinstance(keys_data, dict) else keys_data
+        if isinstance(key_list, list):
+            for key in key_list:
+                if key and _matches_prefix(key, prefix) and key not in results:
+                    results.append(key)
+    return results
+
+
+def resolve_teleport_nodes(
+    store: ModelStore,
+    prefix: str,
+    char_path: str | None,
+) -> list[str]:
+    """Build a list of matching teleport node keys.
+
+    Checks character-specific nodes first, then global nodes.
+    """
+    results: list[str] = []
+    seen: set[str] = set()
+
+    # Character-specific nodes
+    if char_path:
+        try:
+            node_refs = store.get(f"{char_path}.nodes._value")
+            for ref in node_refs:
+                try:
+                    node_data = store.get(ref["rid"])
+                    key = node_data.get("key", "")
+                    if key and key not in seen and _matches_prefix(key, prefix):
+                        results.append(key)
+                        seen.add(key)
+                except (KeyError, TypeError):
+                    continue
+        except KeyError:
+            pass
+
+    # Global nodes
+    try:
+        nodes = store.get("core.node")
+        for node_key in nodes:
+            node_data = nodes[node_key]
+            if not isinstance(node_data, dict):
+                continue
+            key = node_data.get("key", "")
+            if key and key not in seen and _matches_prefix(key, prefix):
+                results.append(key)
+                seen.add(key)
+    except KeyError:
+        pass
 
     return results

--- a/yreflow/commands/completion.py
+++ b/yreflow/commands/completion.py
@@ -1,0 +1,236 @@
+"""Context-aware tab completion: command detection + prioritized name resolution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..protocol.model_store import ModelStore
+
+
+class CompletionType(Enum):
+    LOCAL_ONLY = auto()            # room chars only
+    LOCAL_PREFERRED = auto()       # room → watch → online
+    AWAKE_WATCH_PREFERRED = auto() # awake only, watch → online
+    WATCH_PREFERRED = auto()       # watch → online
+    NONE = auto()                  # no name completion
+
+
+@dataclass
+class CompletionContext:
+    completion_type: CompletionType
+    prefix: str       # text fragment to match against
+    prose: bool       # True = firstname-first cycling; False = fullname cycling
+
+
+# (prefixes, name_slot_type, after_=_type, name_slot_prose, after_=_prose)
+# Longer prefixes checked first within each group to avoid shadowing.
+_DIRECTED_RULES: list[tuple[tuple[str, ...], CompletionType, CompletionType]] = [
+    (("wh ",),                CompletionType.LOCAL_ONLY,            CompletionType.LOCAL_PREFERRED),
+    (("w ",),                 CompletionType.LOCAL_ONLY,            CompletionType.LOCAL_PREFERRED),
+    (("address ",),           CompletionType.LOCAL_ONLY,            CompletionType.LOCAL_PREFERRED),
+    (("to ",),                CompletionType.LOCAL_ONLY,            CompletionType.LOCAL_PREFERRED),
+    (("@",),                  CompletionType.LOCAL_ONLY,            CompletionType.LOCAL_PREFERRED),
+    (("p ",),                 CompletionType.AWAKE_WATCH_PREFERRED, CompletionType.WATCH_PREFERRED),
+    (("m ",),                 CompletionType.AWAKE_WATCH_PREFERRED, CompletionType.WATCH_PREFERRED),
+    (("mail send ",),         CompletionType.WATCH_PREFERRED,       CompletionType.WATCH_PREFERRED),
+    (("mail s ",),            CompletionType.WATCH_PREFERRED,       CompletionType.WATCH_PREFERRED),
+]
+
+_UNDIRECTED_PROSE_RULES: list[tuple[tuple[str, ...], CompletionType]] = [
+    (("say ",),               CompletionType.LOCAL_PREFERRED),
+    (("\u201c",),             CompletionType.LOCAL_PREFERRED),
+    (("\u201d",),             CompletionType.LOCAL_PREFERRED),
+    (('"',),                  CompletionType.LOCAL_PREFERRED),
+    (("pose ",),              CompletionType.LOCAL_PREFERRED),
+    ((":",),                  CompletionType.LOCAL_PREFERRED),
+    (("ooc ",),               CompletionType.LOCAL_PREFERRED),
+    ((">",),                  CompletionType.LOCAL_PREFERRED),
+]
+
+_UNDIRECTED_NAME_RULES: list[tuple[tuple[str, ...], CompletionType]] = [
+    (("look ",),              CompletionType.LOCAL_ONLY),
+    (("l ",),                 CompletionType.LOCAL_ONLY),
+    (("whois ", "wi "),       CompletionType.WATCH_PREFERRED),
+    (("watch ",),             CompletionType.WATCH_PREFERRED),
+    (("unwatch ",),           CompletionType.WATCH_PREFERRED),
+    (("summon ",),            CompletionType.WATCH_PREFERRED),
+    (("join ",),              CompletionType.WATCH_PREFERRED),
+    (("lead ",),              CompletionType.LOCAL_ONLY),
+    (("follow ",),            CompletionType.LOCAL_ONLY),
+    (("focus ",),             CompletionType.LOCAL_ONLY),
+    (("unfocus ",),           CompletionType.LOCAL_ONLY),
+]
+
+
+def detect_completion_context(text: str) -> CompletionContext:
+    """Determine completion type and prefix from partially-typed input."""
+    # --- Directed commands (have Name=message structure) ---
+    for prefixes, name_type, msg_type in _DIRECTED_RULES:
+        for pfx in prefixes:
+            if text.lower().startswith(pfx):
+                argument = text[len(pfx):]
+                if "=" in argument:
+                    # Cursor is in message slot (after =)
+                    after_eq = argument.split("=", 1)[1]
+                    word = after_eq.rsplit(" ", 1)[-1] if after_eq else ""
+                    return CompletionContext(msg_type, word, prose=True)
+                else:
+                    # Cursor is in name slot (before =)
+                    name_part = argument.lstrip("@")
+                    return CompletionContext(name_type, name_part, prose=False)
+
+    # --- Undirected prose commands (say, pose, ooc, etc.) ---
+    for prefixes, ctype in _UNDIRECTED_PROSE_RULES:
+        for pfx in prefixes:
+            if text.lower().startswith(pfx) or text.startswith(pfx):
+                argument = text[len(pfx):]
+                word = argument.rsplit(" ", 1)[-1] if argument else ""
+                return CompletionContext(ctype, word, prose=True)
+
+    # --- Undirected name-target commands (look, whois, etc.) ---
+    for prefixes, ctype in _UNDIRECTED_NAME_RULES:
+        for pfx in prefixes:
+            if text.lower().startswith(pfx):
+                argument = text[len(pfx):]
+                return CompletionContext(ctype, argument, prose=False)
+
+    # --- Bare text: treat as say (local_preferred prose) ---
+    word = text.rsplit(" ", 1)[-1] if text else ""
+    return CompletionContext(CompletionType.LOCAL_PREFERRED, word, prose=True)
+
+
+# ---------------------------------------------------------------------------
+# Tier builders
+# ---------------------------------------------------------------------------
+
+def _get_room_char_ids(store: ModelStore, char_path: str | None) -> list[str]:
+    """Get character IDs of everyone in the active character's room."""
+    if not char_path:
+        return []
+    room_pointer = store.get_room_rid(char_path)
+    if not room_pointer:
+        return []
+    result = []
+    for entry in store.get_room_chars(room_pointer):
+        try:
+            result.append(entry["rid"].split(".")[2])
+        except (KeyError, IndexError):
+            continue
+    return result
+
+
+def _get_watch_char_ids(store: ModelStore, player: str | None) -> list[str]:
+    """Get character IDs from the player's watch list."""
+    if not player:
+        return []
+    try:
+        watches = store.get(f"note.player.{player}.watches")
+    except KeyError:
+        return []
+    result = []
+    for key in watches:
+        try:
+            char_note = store.get(watches[key]["rid"])
+            char_id = char_note["char"]["rid"].split(".")[2]
+            result.append(char_id)
+        except (KeyError, IndexError):
+            continue
+    return result
+
+
+def _get_online_char_ids(store: ModelStore) -> list[str]:
+    """Get all awake character IDs from the store."""
+    try:
+        chars = store.get("core.char")
+    except KeyError:
+        return []
+    result = []
+    for key, char in chars.items():
+        if char.get("awake") and "name" in char:
+            result.append(key)
+    return result
+
+
+def _build_fullname(store: ModelStore, char_id: str) -> str:
+    name = store.get_character_attribute(char_id, "name")
+    surname = store.get_character_attribute(char_id, "surname")
+    return f"{name} {surname}".strip()
+
+
+def _matches_prefix(fullname: str, prefix: str) -> bool:
+    if not prefix:
+        return True
+    return fullname.casefold().startswith(prefix.casefold())
+
+
+# ---------------------------------------------------------------------------
+# Main resolver
+# ---------------------------------------------------------------------------
+
+def resolve_names(
+    store: ModelStore,
+    prefix: str,
+    completion_type: CompletionType,
+    char_path: str | None,
+    player: str | None,
+    prose: bool,
+) -> list[str]:
+    """Build a prioritized, deduplicated name list for tab completion.
+
+    Returns fullnames (or interleaved firstname/fullname for prose mode).
+    """
+    if completion_type == CompletionType.NONE:
+        return []
+
+    # Build tier lists of char_ids based on completion type
+    tiers: list[list[str]] = []
+    awake_filter = False
+
+    if completion_type == CompletionType.LOCAL_ONLY:
+        tiers = [_get_room_char_ids(store, char_path)]
+    elif completion_type == CompletionType.LOCAL_PREFERRED:
+        tiers = [
+            _get_room_char_ids(store, char_path),
+            _get_watch_char_ids(store, player),
+            _get_online_char_ids(store),
+        ]
+    elif completion_type == CompletionType.AWAKE_WATCH_PREFERRED:
+        awake_filter = True
+        tiers = [
+            _get_watch_char_ids(store, player),
+            _get_online_char_ids(store),
+        ]
+    elif completion_type == CompletionType.WATCH_PREFERRED:
+        tiers = [
+            _get_watch_char_ids(store, player),
+            _get_online_char_ids(store),
+        ]
+
+    # Collect matches with deduplication across tiers
+    seen: set[str] = set()
+    results: list[str] = []
+
+    for tier in tiers:
+        for char_id in tier:
+            if char_id in seen:
+                continue
+            if awake_filter and not store.get_character_attribute(char_id, "awake", False):
+                continue
+            fullname = _build_fullname(store, char_id)
+            if not _matches_prefix(fullname, prefix):
+                continue
+            seen.add(char_id)
+
+            if prose:
+                # Offer firstname first, then fullname (skip dup if no surname)
+                firstname = store.get_character_attribute(char_id, "name")
+                results.append(firstname)
+                if fullname != firstname:
+                    results.append(fullname)
+            else:
+                results.append(fullname)
+
+    return results

--- a/yreflow/commands/handler.py
+++ b/yreflow/commands/handler.py
@@ -568,12 +568,15 @@ class CommandHandler:
         # Fall back to global nodes
         if not node_id:
             try:
-                nodes = self.store.get("core.node")
-                for node_key in nodes:
-                    node_data = nodes[node_key]
-                    if "key" in node_data and node_data["key"].lower() == location_key:
-                        node_id = node_data["id"]
-                        break
+                global_refs = self.store.get("core.nodes._value")
+                for ref in global_refs:
+                    try:
+                        node_data = self.store.get(ref["rid"])
+                        if "key" in node_data and node_data["key"].lower() == location_key:
+                            node_id = node_data["id"]
+                            break
+                    except (KeyError, TypeError):
+                        continue
             except KeyError:
                 pass
 

--- a/yreflow/commands/handler.py
+++ b/yreflow/commands/handler.py
@@ -349,6 +349,14 @@ class CommandHandler:
             "function": self.handle_mute_travel,
         }
 
+        patterns["mute_ooc"] = {
+            "patterns": [
+                (lambda cmd: cmd.strip() == "mute ooc", lambda cmd: True),
+                (lambda cmd: cmd.strip() == "unmute ooc", lambda cmd: False),
+            ],
+            "function": self.handle_mute_ooc,
+        }
+
         patterns["nav"] = {
             "patterns": [
                 (lambda cmd: cmd.strip() == "nav", lambda cmd: ""),
@@ -1026,6 +1034,17 @@ class CommandHandler:
         )
         label = "muted" if mute else "unmuted"
         return CommandResult(notification=f"Travel messages {label}.")
+
+    async def handle_mute_ooc(self, mute: bool, cc: ControlledChar) -> CommandResult:
+        player = self.conn.player
+        if not player:
+            return CommandResult(success=False, notification="Not connected.")
+        await self.conn.send(
+            f"call.core.player.{player}.setCharSettings",
+            {"charId": cc.char_id, "muteOoc": mute},
+        )
+        label = "muted" if mute else "unmuted"
+        return CommandResult(notification=f"OOC messages {label}.")
 
     async def handle_nav(self, content: str, cc: ControlledChar) -> CommandResult:
         return CommandResult(toggle_nav=True)

--- a/yreflow/commands/handler.py
+++ b/yreflow/commands/handler.py
@@ -341,6 +341,14 @@ class CommandHandler:
             "function": self.handle_describe,
         }
 
+        patterns["mute_travel"] = {
+            "patterns": [
+                (lambda cmd: cmd.strip() == "mute travel", lambda cmd: True),
+                (lambda cmd: cmd.strip() == "unmute travel", lambda cmd: False),
+            ],
+            "function": self.handle_mute_travel,
+        }
+
         patterns["nav"] = {
             "patterns": [
                 (lambda cmd: cmd.strip() == "nav", lambda cmd: ""),
@@ -1007,6 +1015,17 @@ class CommandHandler:
 
     async def handle_settings(self, content: str, cc: ControlledChar) -> CommandResult:
         return CommandResult(open_settings=True)
+
+    async def handle_mute_travel(self, mute: bool, cc: ControlledChar) -> CommandResult:
+        player = self.conn.player
+        if not player:
+            return CommandResult(success=False, notification="Not connected.")
+        await self.conn.send(
+            f"call.core.player.{player}.setCharSettings",
+            {"charId": cc.char_id, "muteTravel": mute},
+        )
+        label = "muted" if mute else "unmuted"
+        return CommandResult(notification=f"Travel messages {label}.")
 
     async def handle_nav(self, content: str, cc: ControlledChar) -> CommandResult:
         return CommandResult(toggle_nav=True)

--- a/yreflow/commands/handler.py
+++ b/yreflow/commands/handler.py
@@ -159,6 +159,7 @@ class CommandHandler:
         patterns["teleport"] = {
             "patterns": [
                 (lambda cmd: cmd.startswith("teleport "), lambda cmd: cmd[9:]),
+                (lambda cmd: cmd.startswith("tport "), lambda cmd: cmd[6:]),
                 (lambda cmd: cmd.startswith("t "), lambda cmd: cmd[2:]),
             ],
             "function": self.handle_teleport,

--- a/yreflow/protocol/connection.py
+++ b/yreflow/protocol/connection.py
@@ -498,7 +498,11 @@ class WolferyConnection:
             msg["params"] = params
         raw = json.dumps(msg)
         self.log_to_file(f"OUTGOING: {raw}")
-        await self.wsock.send(raw)
+        try:
+            await self.wsock.send(raw)
+        except websockets.exceptions.ConnectionClosedError:
+            self.log_to_file("SEND FAILED: connection already closed")
+            return 0
         await asyncio.sleep(0)
         return self.id
 

--- a/yreflow/protocol/connection.py
+++ b/yreflow/protocol/connection.py
@@ -514,5 +514,5 @@ class WolferyConnection:
         current_date = datetime.now().strftime("%Y-%m-%d")
         log_file = log_dir / f"{current_date}.log"
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        with open(log_file, "a") as f:
+        with open(log_file, "a", encoding="utf-8") as f:
             f.write(f"[{timestamp}] {message}\n")

--- a/yreflow/ui/app.py
+++ b/yreflow/ui/app.py
@@ -71,6 +71,7 @@ class WolferyCommands(Provider):
 
 _UNIMPORTANT_STYLES = {"sleep", "leave", "arrive", "travel", "action", "wakeup"}
 _TRAVEL_STYLES = {"leave", "arrive", "travel", "wakeup", "sleep"}
+_OOC_STYLES = {"ooc"}
 _CONSOLE_ID = "__console__"
 
 
@@ -560,6 +561,18 @@ class WolferyApp(App):
         except (KeyError, AttributeError):
             return True
 
+    def _get_mute_ooc(self, character: str) -> bool:
+        """Check the muteOoc setting for a character. Defaults to False."""
+        if not self.controller:
+            return False
+        store = self.controller.store
+        cc = self.controller.connection.get_controlled_char(character)
+        char_id = cc.char_id if cc else character
+        try:
+            return bool(store.get(f"core.char.{char_id}.settings.muteOoc"))
+        except (KeyError, AttributeError):
+            return False
+
     # --- Focus color ---
 
     def _get_focus_color(self, sender_id: str, character: str) -> str | None:
@@ -588,12 +601,15 @@ class WolferyApp(App):
 
         views = self.character_views[character]
         mute_travel = self._get_mute_travel(character)
+        mute_ooc = self._get_mute_ooc(character)
         if style in self.unimportant_styles:
             # If muteTravel is off, travel messages go to the main view
             if not mute_travel and style in _TRAVEL_STYLES:
                 view = views["main"]
             else:
                 view = views["unimportant"]
+        elif mute_ooc and style in _OOC_STYLES:
+            view = views["unimportant"]
         else:
             view = views["main"]
 
@@ -632,8 +648,9 @@ class WolferyApp(App):
         view.write(f"{line}")
 
         # Unread tracking for non-active characters
-        is_muted = style in self.unimportant_styles and not (
-            not mute_travel and style in _TRAVEL_STYLES
+        is_muted = (
+            (style in self.unimportant_styles and not (not mute_travel and style in _TRAVEL_STYLES))
+            or (mute_ooc and style in _OOC_STYLES)
         )
         if character != self.active_character and not is_muted:
             self.unread_counts[character] = self.unread_counts.get(character, 0) + 1

--- a/yreflow/ui/app.py
+++ b/yreflow/ui/app.py
@@ -47,7 +47,7 @@ class WolferyCommands(Provider):
     """Command palette entries for yreflow actions."""
 
     COMMANDS = [
-        ("Toggle activity panel", "toggle_unimportant", "Show/hide the activity section (F3)"),
+        ("Toggle muted panel", "toggle_unimportant", "Show/hide the muted section (F3)"),
         ("Recent URLs", "show_urls", "Show recently captured URLs (Ctrl+U)"),
         ("Toggle sidebar mode", "toggle_watch_mode", "Switch sidebar between compact and full (Ctrl+W)"),
         ("Next character", "next_character", "Switch to the next character tab (Ctrl+N)"),
@@ -70,6 +70,7 @@ class WolferyCommands(Provider):
 
 
 _UNIMPORTANT_STYLES = {"sleep", "leave", "arrive", "travel", "action", "wakeup"}
+_TRAVEL_STYLES = {"leave", "arrive", "travel", "wakeup", "sleep"}
 _CONSOLE_ID = "__console__"
 
 
@@ -112,7 +113,7 @@ class WolferyApp(App):
     BINDINGS = [
         Binding("ctrl+c", "quit", "Quit", priority=True),
         Binding("ctrl+u", "show_urls", "URLs", priority=True),
-        Binding("f3", "toggle_unimportant", "Toggle activity", priority=True),
+        Binding("f3", "toggle_unimportant", "Toggle muted", priority=True),
         Binding("ctrl+w", "toggle_watch_mode", "Sidebar: compact/full", priority=True),
         Binding("ctrl+p", "prev_character", "Prev char", priority=True),
         Binding("ctrl+n", "next_character", "Next char", priority=True),
@@ -545,6 +546,20 @@ class WolferyApp(App):
         input_bar = self.query_one("#input-bar", InputBar)
         input_bar.update_spellcheck_words(words)
 
+    # --- Character settings helpers ---
+
+    def _get_mute_travel(self, character: str) -> bool:
+        """Check the muteTravel setting for a character. Defaults to True."""
+        if not self.controller:
+            return True
+        store = self.controller.store
+        cc = self.controller.connection.get_controlled_char(character)
+        char_id = cc.char_id if cc else character
+        try:
+            return bool(store.get(f"core.char.{char_id}.settings.muteTravel"))
+        except (KeyError, AttributeError):
+            return True
+
     # --- Focus color ---
 
     def _get_focus_color(self, sender_id: str, character: str) -> str | None:
@@ -572,8 +587,13 @@ class WolferyApp(App):
             return
 
         views = self.character_views[character]
+        mute_travel = self._get_mute_travel(character)
         if style in self.unimportant_styles:
-            view = views["unimportant"]
+            # If muteTravel is off, travel messages go to the main view
+            if not mute_travel and style in _TRAVEL_STYLES:
+                view = views["main"]
+            else:
+                view = views["unimportant"]
         else:
             view = views["main"]
 
@@ -612,7 +632,10 @@ class WolferyApp(App):
         view.write(f"{line}")
 
         # Unread tracking for non-active characters
-        if character != self.active_character and style not in self.unimportant_styles:
+        is_muted = style in self.unimportant_styles and not (
+            not mute_travel and style in _TRAVEL_STYLES
+        )
+        if character != self.active_character and not is_muted:
             self.unread_counts[character] = self.unread_counts.get(character, 0) + 1
             if style in ("whisper", "message", "address"):
                 self.urgent_unreads[character] = True
@@ -724,7 +747,7 @@ class WolferyApp(App):
         )
         collapsible = Collapsible(
             unimportant_view,
-            title="Activity",
+            title="Muted",
             id=f"collapse-{character}",
             collapsed=True,
         )

--- a/yreflow/ui/widgets/input_bar.py
+++ b/yreflow/ui/widgets/input_bar.py
@@ -9,7 +9,7 @@ from textual.widgets import Input
 
 from ..highlighters import CompositeHighlighter, MarkupPreviewHighlighter, SpellCheckHighlighter
 
-from ...commands.name_resolver import NameParseException, parse_name
+from ...commands.completion import detect_completion_context, resolve_names, CompletionType
 
 # Keys that should pass through to app-level bindings even when input is focused.
 _PASSTHROUGH_KEYS = {
@@ -115,24 +115,26 @@ class InputBar(Input):
             self.cycle_completion()
             return
 
-        lookup = self.value.split(' ')[-1]
-        if not lookup:
-            return
-        if lookup[0] in '@':
-            lookup = lookup[1:]
-
-        # If there's nothing to autocomplete, just stop.
-        if not lookup:
+        ctx = detect_completion_context(self.value)
+        if ctx.completion_type == CompletionType.NONE or not ctx.prefix:
             return
 
-        self._autocomplete_to = self.cursor_position-1
-        self._autocomplete_length = len(lookup)
-
-        try:
-            results = parse_name(self.app.controller.store, lookup, 'fullname', True, True)
-        except NameParseException:
+        controller = self.app.controller
+        if not controller:
             return
 
+        char_path = self.app._resolve_char_path(self.app.active_character) if self.app.active_character else None
+        player = controller.connection.player
+
+        results = resolve_names(
+            controller.store, ctx.prefix, ctx.completion_type,
+            char_path, player, ctx.prose,
+        )
+        if not results:
+            return
+
+        self._autocomplete_to = self.cursor_position - 1
+        self._autocomplete_length = len(ctx.prefix)
         self._autocomplete_history = deque(results)
         self._autocompleting = True
 

--- a/yreflow/ui/widgets/input_bar.py
+++ b/yreflow/ui/widgets/input_bar.py
@@ -9,7 +9,9 @@ from textual.widgets import Input
 
 from ..highlighters import CompositeHighlighter, MarkupPreviewHighlighter, SpellCheckHighlighter
 
-from ...commands.completion import detect_completion_context, resolve_names, CompletionType
+from ...commands.completion import (
+    detect_completion_context, resolve_names, resolve_exits, resolve_teleport_nodes, CompletionType,
+)
 
 # Keys that should pass through to app-level bindings even when input is focused.
 _PASSTHROUGH_KEYS = {
@@ -126,10 +128,15 @@ class InputBar(Input):
         char_path = self.app._resolve_char_path(self.app.active_character) if self.app.active_character else None
         player = controller.connection.player
 
-        results = resolve_names(
-            controller.store, ctx.prefix, ctx.completion_type,
-            char_path, player, ctx.prose,
-        )
+        if ctx.completion_type == CompletionType.EXITS:
+            results = resolve_exits(controller.store, ctx.prefix, char_path)
+        elif ctx.completion_type == CompletionType.TELEPORT_NODES:
+            results = resolve_teleport_nodes(controller.store, ctx.prefix, char_path)
+        else:
+            results = resolve_names(
+                controller.store, ctx.prefix, ctx.completion_type,
+                char_path, player, ctx.prose,
+            )
         if not results:
             return
 


### PR DESCRIPTION
## Mute Changes
* Changes 'Activity' to 'Muted'
* Aligned definitions of muted with naming.  I.e. with mute travel on the travel messages will appear in 'Muted', and not if not.   Same with mute ooc.
* Added mute travel and mute ooc commands.

## Bugfixes
* Autocomplete is now context aware.   Note it tries to be better than mainline client, not match exactly.
* Fixes #60, #85 and #86.
* Fixes #87 - Default cp1252 output file crashes client on Windows 10.